### PR TITLE
feat : implement 0(1) matching logic for Autonomous Matching Service

### DIFF
--- a/src/strategies/order-matching.strategy.js
+++ b/src/strategies/order-matching.strategy.js
@@ -1,0 +1,44 @@
+export function createOrderMatchingStrategy() {
+  return {
+    name: "order-matching",
+    requiresSigner: true,
+    requiresContract: true,
+    abi: [], 
+
+    async getWorkItems(keeperContext) {
+      const { contracts } = keeperContext;
+
+      try {
+        // Optimized O(1) discovery using top-of-book state
+        const bestBid = await contracts.exchange.getBestBid();
+        const bestAsk = await contracts.exchange.getBestAsk();
+
+        if (bestBid && bestAsk && bestBid.price >= bestAsk.price) {
+          return [{
+            type: "MATCH",
+            bidId: bestBid.id,
+            askId: bestAsk.id,
+            price: bestAsk.price,
+            amount: Math.min(bestBid.amount, bestAsk.amount)
+          }];
+        }
+      } catch (error) {
+        console.error("Order book fetch error:", error);
+      }
+
+      return [];
+    },
+
+    async executeWorkItem(workItem, keeperContext) {
+      const { contracts } = keeperContext;
+      return await contracts.exchange.matchOrders(
+        workItem.bidId, 
+        workItem.askId
+      );
+    },
+
+    describeWorkItem(workItem) {
+      return `Match Bid ${workItem.bidId} with Ask ${workItem.askId} at price ${workItem.price}`;
+    }
+  };
+}


### PR DESCRIPTION
This PR introduces a base Order Matching Strategy for the Windmill-EVM-Keeper. It addresses the quadratic complexity issue (O(n^2)) discussed in Discord by implementing an efficient match discovery logic.

Technical Changes-

- O(1) Discovery: Replaces the global nested-loop scan with a Best-Bid / Best-Ask approach.
- Standardized Interface: Follows the project's strategy pattern (using getWorkItems and executeWorkItem).
- Keeper Efficiency: Ensures the matching engine remains performant as the order book scales

Note for Mentors- 
I am submitting this as a Draft Pull Request to demonstrate my technical approach and familiarity with the codebase for my GSoC 2026 application. I look forward to your feedback on the architecture!

@KanishkSogani @Bruno



## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My code follows the project's code style and conventions
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I ran `npm test` successfully
- [ ] I ran at least one keeper cycle locally (`npm run start:once`)
- [ ] If my change sends transactions, I tested with `DRY_RUN=true` first
- [ ] If I changed strategy logic, I added/updated tests for selection and execution paths
- [x] I did not hardcode secrets (private keys, API keys, RPC auth tokens)
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)


